### PR TITLE
Updated the show more attendees logic

### DIFF
--- a/src/content/ContentApp.tsx
+++ b/src/content/ContentApp.tsx
@@ -8,13 +8,17 @@ const ContentApp = () => {
     const [activeAttendeeId, setActiveAttendeeId] = useState<string>('');
 
     const clickAttendee = (attendeeId: string) => {
-        const checkbox = document.getElementById('assignee-' + attendeeId);
+        let checkbox = document.getElementById('assignee-' + attendeeId);
         if (checkbox) {
             checkbox.click();
         } else {
-            document.getElementById('assignee-show-more')?.click();
-            document.getElementById(attendeeId)?.click();
-            document.getElementById('assignee-show-more')?.click();
+            const showMoreQuery = '[data-testid*="assignee-filter-show-more"]';
+            document.querySelector<HTMLElement>(showMoreQuery)?.click();
+            checkbox = document.getElementById(attendeeId);
+            if (checkbox) {
+                checkbox.click();
+            }
+            document.querySelector<HTMLElement>(showMoreQuery)?.click();
         }
     };
 


### PR DESCRIPTION
There appears to be a break in functionality wherein if the user is not the main list and the "Show More" button needs to be "clicked" the filtering will not work. Looking into Jira's markdown there appears to have been a change and uses a data-testid instead of id

![image](https://github.com/user-attachments/assets/a18c4d4c-ffce-4e66-bd58-d905f1e46063)

Console:
![image](https://github.com/user-attachments/assets/77322047-51ac-4b01-811c-d6d85fcafb5f)
